### PR TITLE
fixed path to package.json

### DIFF
--- a/gify-parse-cli.js
+++ b/gify-parse-cli.js
@@ -24,11 +24,12 @@
  */
 (function () {
     var fs = require('fs');
+    var path = require('path');
 
     var program = require('commander');
 
     var gifyParse = require('./gify-parse');
-    var version = JSON.parse(fs.readFileSync('./package.json', 'UTF-8')).version;
+    var version = JSON.parse(fs.readFileSync(path.join(__dirname,  './package.json'), 'UTF-8')).version;
 
     program
         .version(version)


### PR DESCRIPTION
When execute from another directory, the `package.json` cannot be found since its relative to the script. I fixed it by prefixing it with __dirname.
